### PR TITLE
Issue 1 issue 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,30 @@ Instructions:
 
 ## Usage instructions
 
-Run this tool with `release-notes-generator <path> <version1> <version2>`. Arguments:
+Run this tool with `release-notes-generator generate <path> <version1> <version2>`. Arguments:
 - `<path>`: Path to the GIT repo you want to generate a release notes for
 - `<version1>`, and `<version2>`: Versions that define the range of commits your release notes will include
 
 Example: `release-notes-generator /home/guillermo/src/odk/briefcase v1.11.0 v1.12.0`
 
-  (This will generate a release notes for Briefcase between versions v1.11.0 and v1.12.0)  
+  (This will generate a release notes for Briefcase between versions v1.11.0 and v1.12.0)
+  
+## Advanced usage: preload authors table
+
+Use the following JSON file as a template to feed the authors to the tool:
+
+```json
+[
+  {
+    "name": "Jane Doe",
+    "email": "jane@doe.com",
+    "username": "the-jane-doe",
+    "organization": "Doe & Doe Corp."
+  }
+]
+
+```  
+
+You can feed a JSON with authors with the command `release-notes-generator feed-authors <path>`.
+
+You can check the current authors table (and use it as a template as well) with the command `release-notes-generator print-authors`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "odk-release-notes",
-  "version": "0.1.5",
+  "name": "release-notes-generator",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -87,6 +87,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "write-file-atomic": {
       "version": "1.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,16 @@
         "sprintf-js": "1.0.3"
       }
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
+    },
     "ejs": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
@@ -76,6 +86,15 @@
         "mkdirp": "0.5.1",
         "os-homedir": "1.0.2",
         "write-file-atomic": "1.3.4"
+      }
+    },
+    "sha1": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/sha1/-/sha1-1.1.1.tgz",
+      "integrity": "sha1-rdqnqTFo85PxnrKxUJFhjicA+Eg=",
+      "requires": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2"
       }
     },
     "slide": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "release-notes-generator",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Tool that generates the release note items between two git tags for ODK projects",
   "main": "src/generate.js",
   "scripts": {},
@@ -12,7 +12,7 @@
   "license": "Apache 2.0",
   "preferGlobal": true,
   "bin": {
-    "release-notes-generator": "src/generate.js"
+    "release-notes-generator": "src/main.js"
   },
   "bugs": {
     "url": "https://github.com/opendatakit/release-notes-generator/issues"
@@ -22,6 +22,7 @@
     "ejs": "latest",
     "luxon": "^1.4.3",
     "preferences": "^1.0.2",
+    "sha1": "^1.1.1",
     "uuid": "^3.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "ejs": "latest",
     "luxon": "^1.4.3",
-    "preferences": "^1.0.2"
+    "preferences": "^1.0.2",
+    "uuid": "^3.3.2"
   }
 }

--- a/src/author.js
+++ b/src/author.js
@@ -1,0 +1,45 @@
+const uuidv4 = require('uuid').v4;
+const Option = require('./option');
+const sha1 = require('sha1');
+
+class Author {
+  constructor(uuid, name, emailHash, username, organization) {
+    this.uuid = uuid;
+    this.name = name;
+    this.emailHash = emailHash;
+    this.username = username;
+    this.organization = organization;
+  }
+
+  static fromJson({uuid, name, email, emailHash, username, organization}) {
+    uuid = Option.of(uuid).orElseGet(uuidv4);
+    emailHash = Option.race(Option.of(emailHash), Option.of(email).map(sha1)).orUndefined();
+    return new Author(uuid, name, emailHash, username, organization);
+  }
+
+  static empty() {
+    return new Author(uuidv4());
+  }
+
+  merge(other) {
+    if (!(other instanceof Author))
+      throw new Error("Can't merge with something that's not an Author");
+    return new Author(
+        this.uuid || other.uuid,
+        this.name || other.name,
+        this.emailHash || other.emailHash,
+        this.username || other.username,
+        this.organization || other.organization
+    );
+  }
+
+  buildSignature() {
+    return [
+      Option.of(this.name),
+      Option.of(this.username).map(username => username.startsWith("@") ? username : `@${username}`),
+      Option.of(this.organization).map(organization => `(${organization})`)
+    ].filter(o => o.isPresent()).map(o => o.get()).join(" ");
+  }
+}
+
+module.exports = Author;

--- a/src/authors.js
+++ b/src/authors.js
@@ -1,6 +1,103 @@
 const Preferences = require('preferences');
-const namesByUsername = new Preferences('org.opendatakit.release-notes-generator.names-by-username', {}, {encrypt: false, format: 'json'});
-const usernamesByEmail = new Preferences('org.opendatakit.release-notes-generator.usernames-by-email', {}, {encrypt: false, format: 'json'});
+const uuidv4 = require('uuid').v4;
+const Option = require('./option');
+const namesByUsername = new Preferences('org.opendatakit.release-notes-generator.names-by-username', {}, {
+  encrypt: false,
+  format: 'json'
+});
+const usernamesByEmail = new Preferences('org.opendatakit.release-notes-generator.usernames-by-email', {}, {
+  encrypt: false,
+  format: 'json'
+});
+const authors = new Preferences('org.opendatakit.release-notes-generator.authors', {}, {
+  encrypt: false,
+  format: 'json'
+});
+
+class Author {
+  constructor(uuid, name, email, username, organization) {
+    this.uuid = uuid;
+    this.name = name;
+    this.email = email;
+    this.username = username;
+    this.organization = organization;
+  }
+
+  static fromJson({uuid, name, email, username, organization}) {
+    return new Author(uuid || uuidv4(), name, email, username, organization);
+  }
+
+  static empty() {
+    return new Author(uuidv4());
+  }
+
+  getKey() {
+
+  }
+
+  merge(other) {
+    if (!(other instanceof Author))
+      throw new Error("Can't merge with something that's not an Author");
+    return new Author(
+        this.uuid || other.uuid,
+        this.name || other.name,
+        this.email || other.email,
+        this.username || other.username,
+        this.organization || other.organization
+    );
+  }
+}
+
+const parse = regexp => text => regexp.exec(text)[1];
+const parseUsername = parse(/ from (.+?)\//);
+
+const searchAuthor = (authors, {uuid, username, email, name}) => {
+  if (uuid !== undefined && authors[uuid] !== undefined)
+    return authors[uuid];
+
+  for (let author of valuesOf(authors)) {
+    if ((author.username !== undefined && author.username === username) ||
+        (author.email !== undefined && author.email === email) ||
+        (author.name !== undefined && author.name === name))
+      return Option.of(author).map(Author.fromJson);
+  }
+  return Option.empty();
+};
+
+const valuesOf = obj => Object.values(obj);
+
+exports.feedAuthors = json => {
+  const valuesOf1 = valuesOf(json);
+  valuesOf1
+      .map(Author.fromJson)
+      .map(incomingAuthor => {
+        const searchAuthor1 = searchAuthor(authors, incomingAuthor);
+        const value = Author.empty();
+        const orElse = searchAuthor1.orElse(value);
+        const merge = orElse.merge(incomingAuthor);
+        return merge;
+      })
+      .forEach(author => authors[author.uuid] = author);
+  console.log(authors);
+};
+
+exports.feedCommit = commit => {
+  if (commit.committerName === "GitHub") {
+    // This is a "merge commit" type. The author is the guy who merged the PR, not the real author
+    const incomingAuthor = Author.fromJson({username: parseUsername(commit.title)});
+    const author = searchAuthor(authors, incomingAuthor).orElse(Author.empty()).merge(incomingAuthor);
+    authors[author.uuid] = author;
+  } else {
+    // This is a "squash merge" or a "rebase and merge" type
+    const incomingAuthor = Author.fromJson({
+      name: commit.authorName,
+      email: commit.authorEmail.endsWith('users.noreply.github.com') ? undefined : commit.authorEmail,
+      username: commit.authorEmail.endsWith('users.noreply.github.com') ? commit.authorEmail.substring(0, commit.authorEmail.indexOf("@")) : undefined
+    });
+    const author = searchAuthor(authors, incomingAuthor).orElse(Author.empty()).merge(incomingAuthor);
+    authors[author.uuid] = author;
+  }
+};
 
 exports.usernameByEmail = (email, name) => {
   const beforeAt = email.substring(email.indexOf('+') + 1, email.indexOf('@'));
@@ -15,3 +112,8 @@ exports.usernameByEmail = (email, name) => {
 };
 
 exports.nameByUsername = username => namesByUsername[username] !== undefined ? namesByUsername[username] : username;
+
+exports.print = () => {
+  console.log(namesByUsername);
+  console.log(usernamesByEmail)
+};

--- a/src/feed-authors.js
+++ b/src/feed-authors.js
@@ -1,12 +1,5 @@
-#!/usr/bin/env node
-
 const authors = require('./authors');
 const promisify = require('util').promisify;
 const readFile = promisify(require("fs").readFile);
 
-const run = async path => {
-  const json = await readFile(path);
-  authors.feedAuthors(JSON.parse(json.toString("utf8")));
-};
-
-run(process.argv[2]).catch(error => console.error(error));
+module.exports = async path => authors.feedAuthors(JSON.parse((await readFile(path)).toString("utf8")));;

--- a/src/feed-authors.js
+++ b/src/feed-authors.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+const authors = require('./authors');
+const promisify = require('util').promisify;
+const readFile = promisify(require("fs").readFile);
+
+const run = async path => {
+  const json = await readFile(path);
+  authors.feedAuthors(JSON.parse(json.toString("utf8")));
+};
+
+run(process.argv[2]).catch(error => console.error(error));

--- a/src/generate.js
+++ b/src/generate.js
@@ -25,4 +25,22 @@ const run = async (range, cwd) => {
   console.log(output);
 };
 
-run(`${process.argv[3]}..${process.argv[4]}`, process.argv[2]).catch(error => console.error(error));
+module.exports = async (range, cwd) => {
+  const mergeCommits = await git.getMergeCommits(range, cwd);
+  const mergeCommitTpl = await tpls.read('merge-commits');
+
+  const squashMerges = await git.getSquashMerges(range, cwd);
+  const squashMergeTpl = await tpls.read('squash-merges');
+
+  // Pair commits up with their corresponding tpl
+  const pairs = [];
+  mergeCommits.forEach(commit => pairs.push([commit, mergeCommitTpl]));
+  squashMerges.forEach(commit => pairs.push([commit, squashMergeTpl]));
+
+  const output = pairs
+      .sort(comparingBy(([commit]) => commit.ts.toMillis())) // Sort commits by commit date
+      .map(([commit, tpl]) => ejs.render(tpl, {commits: [commit]})) // Render each commit individually
+      .join("\n"); // Join all into the output text
+
+  console.log(output);
+};

--- a/src/git.js
+++ b/src/git.js
@@ -61,26 +61,21 @@ const log = async (range, cwd, mergesOnly) => {
   )).map(asEntry);
 };
 
-const parseUsername = parse(/ from (.+?)\//);
 const parsePR = parse(/Merge pull request #(\d+)/);
 
 const mergeCommitFilter = commit => /Merge pull request #(\d+)/.test(commit.title);
 const mergeCommitMapper = commit => {
-  authors.feedCommit(commit);
-  const username = parseUsername(commit.title);
   const pr = parsePR(commit.title);
   commit['ts'] = DateTime.fromISO(commit.committerDate);
-  commit['authorUsername'] = username;
-  commit['realAuthorName'] = authors.nameByUsername(username);
+  commit['author'] = authors.feedCommit(commit);
   commit['pr'] = pr;
   return commit;
 };
 
 const squashMergeFilter = commit => commit.committerName !== 'GitHub' && commit.committerName !== commit.authorName;
 const squashMergeMapper = commit => {
-  authors.feedCommit(commit);
   commit['ts'] = DateTime.fromISO(commit.committerDate);
-  commit['authorUsername'] = authors.usernameByEmail(commit.authorEmail, commit.authorName);
+  commit['author'] = authors.feedCommit(commit);
   return commit;
 };
 

--- a/src/git.js
+++ b/src/git.js
@@ -66,6 +66,7 @@ const parsePR = parse(/Merge pull request #(\d+)/);
 
 const mergeCommitFilter = commit => /Merge pull request #(\d+)/.test(commit.title);
 const mergeCommitMapper = commit => {
+  authors.feedCommit(commit);
   const username = parseUsername(commit.title);
   const pr = parsePR(commit.title);
   commit['ts'] = DateTime.fromISO(commit.committerDate);
@@ -77,6 +78,7 @@ const mergeCommitMapper = commit => {
 
 const squashMergeFilter = commit => commit.committerName !== 'GitHub' && commit.committerName !== commit.authorName;
 const squashMergeMapper = commit => {
+  authors.feedCommit(commit);
   commit['ts'] = DateTime.fromISO(commit.committerDate);
   commit['authorUsername'] = authors.usernameByEmail(commit.authorEmail, commit.authorName);
   return commit;

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+const generate = require('./generate');
+const feedAuthors = require('./feed-authors');
+const printAuthors = require('./print-authors');
+
+const run = async ([__, ___, command, ...args]) => {
+  if (command === 'generate')
+    return generate(`${args[1]}..${args[2]}`, args[0])
+  if (command === 'feed-authors')
+    return feedAuthors(args[0]);
+  if (command === 'print-authors')
+    return printAuthors();
+  throw new Error("You must specify a command: generate | feed-authors | print-authors")
+};
+
+run(process.argv).catch(error => console.error(error));
+

--- a/src/option.js
+++ b/src/option.js
@@ -1,0 +1,57 @@
+class Option {
+  static of(value) {
+    if (value === undefined || value === null)
+      return None.NONE;
+    return new Some(value);
+  }
+
+  static empty() {
+    return None.NONE;
+  }
+
+  orElse(value) {
+  }
+
+  map(mapper) {
+  }
+
+  isEmpty() {
+  }
+}
+
+class None extends Option {
+  orElse(value) {
+    return value;
+  }
+
+  map(mapper) {
+    return this;
+  }
+
+  isEmpty() {
+    return true;
+  }
+}
+
+None.NONE = new None();
+
+class Some extends Option {
+  constructor(value) {
+    super();
+    this.value = value;
+  }
+
+  orElse(value) {
+    return this.value;
+  }
+
+  map(mapper) {
+    return Option.of(mapper(this.value));
+  }
+
+  isEmpty() {
+    return false;
+  }
+}
+
+module.exports = Option;

--- a/src/option.js
+++ b/src/option.js
@@ -9,10 +9,29 @@ class Option {
     return None.NONE;
   }
 
+  static race(...options) {
+    for (let option of options)
+      if (option.isPresent())
+        return option;
+    return None.NONE;
+  }
+
+  get() {
+  }
+
   orElse(value) {
   }
 
+  orElseGet(valueSupplier) {
+  }
+
+  orUndefined() {
+  }
+
   map(mapper) {
+  }
+
+  isPresent() {
   }
 
   isEmpty() {
@@ -20,12 +39,28 @@ class Option {
 }
 
 class None extends Option {
+  get() {
+    throw new Error("Value not present");
+  }
+
   orElse(value) {
     return value;
   }
 
+  orElseGet(valueSupplier) {
+    return valueSupplier();
+  }
+
+  orUndefined() {
+    return undefined;
+  }
+
   map(mapper) {
     return this;
+  }
+
+  isPresent() {
+    return false;
   }
 
   isEmpty() {
@@ -41,12 +76,28 @@ class Some extends Option {
     this.value = value;
   }
 
+  get() {
+    return this.value;
+  }
+
   orElse(value) {
+    return this.value;
+  }
+
+  orElseGet(valueSupplier) {
+    return this.value;
+  }
+
+  orUndefined() {
     return this.value;
   }
 
   map(mapper) {
     return Option.of(mapper(this.value));
+  }
+
+  isPresent() {
+    return true;
   }
 
   isEmpty() {

--- a/src/print-authors.js
+++ b/src/print-authors.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+const authors = require('./authors');
+
+const run = async () => {
+  authors.print();
+};
+
+run().catch(error => console.error(error));

--- a/src/print-authors.js
+++ b/src/print-authors.js
@@ -1,9 +1,3 @@
-#!/usr/bin/env node
-
 const authors = require('./authors');
 
-const run = async () => {
-  authors.print();
-};
-
-run().catch(error => console.error(error));
+module.exports = async () => authors.print();

--- a/src/templates/merge-commits.ejs
+++ b/src/templates/merge-commits.ejs
@@ -1,2 +1,2 @@
 <% commits.forEach(function (commit) { %>- <%= commit.messageLines[0] %> (#<%= commit.pr %>)
-  - <%= commit.realAuthorName %> (@<%= commit.authorUsername %>)<% }) %>
+  - <%= commit.author.buildSignature() %><% }) %>

--- a/src/templates/squash-merges.ejs
+++ b/src/templates/squash-merges.ejs
@@ -1,2 +1,2 @@
 <% commits.forEach(function (commit) { %>- <%= commit.title %>
-  - <%= commit.authorName %> (@<%= commit.authorUsername %>)<% }) %>
+  - <%= commit.author.buildSignature() %><% }) %>


### PR DESCRIPTION
Closes #1 

New usage instructions:

## Usage instructions

Run this tool with `release-notes-generator generate <path> <version1> <version2>`. Arguments:
- `<path>`: Path to the GIT repo you want to generate a release notes for
- `<version1>`, and `<version2>`: Versions that define the range of commits your release notes will include

Example: `release-notes-generator /home/guillermo/src/odk/briefcase v1.11.0 v1.12.0`

  (This will generate a release notes for Briefcase between versions v1.11.0 and v1.12.0)
  
## Advanced usage: preload authors table

Use the following JSON file as a template to feed the authors to the tool:

```json
[
  {
    "name": "Jane Doe",
    "email": "jane@doe.com",
    "username": "the-jane-doe",
    "organization": "Doe & Doe Corp."
  }
]

```  

You can feed a JSON with authors with the command `release-notes-generator feed-authors <path>`.

You can check the current authors table (and use it as a template as well) with the command `release-notes-generator print-authors`
